### PR TITLE
Add Authentication Features: Login, Registration, Invitation, and Current User Retrieval with Email Notifications

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -1,0 +1,59 @@
+import os
+from flask import Flask, jsonify
+from extensions import db, migrate, jwt, mail, cors
+from config import config
+
+def create_app(config_name=None):
+    """Application factory function"""
+    if config_name is None:
+        config_name = os.environ.get('FLASK_CONFIG', 'default')
+    
+    app = Flask(__name__)
+    app.config.from_object(config[config_name])
+    
+    # Initialize extensions
+    db.init_app(app)
+    migrate.init_app(app, db)
+    jwt.init_app(app)
+    mail.init_app(app)
+    cors.init_app(app)
+    
+    # Register routes
+    from routes import auth_bp, inventory_bp, users_bp, reports_bp
+    
+    app.register_blueprint(auth_bp, url_prefix='/api/auth')
+    app.register_blueprint(inventory_bp, url_prefix='/api/inventory')
+    app.register_blueprint(users_bp, url_prefix='/api/users')
+    app.register_blueprint(reports_bp, url_prefix='/api/reports')
+    
+    # JWT error handlers
+    @jwt.expired_token_loader
+    def expired_token_callback(jwt_header, jwt_payload):
+        return jsonify({
+            'status': 'error',
+            'message': 'Token has expired'
+        }), 401
+    
+    @jwt.invalid_token_loader
+    def invalid_token_callback(error):
+        return jsonify({
+            'status': 'error',
+            'message': 'Invalid token'
+        }), 401
+    
+    @jwt.unauthorized_loader
+    def unauthorized_callback(error):
+        return jsonify({
+            'status': 'error',
+            'message': 'Missing authorization token'
+        }), 401
+    
+    @app.route('/api/health')
+    def health_check():
+        return jsonify({'status': 'ok', 'message': 'MyDuka API is running'})
+    
+    return app
+
+if __name__ == '__main__':
+    app = create_app()
+    app.run(host='0.0.0.0', port=5000)

--- a/server/routes/auth.py
+++ b/server/routes/auth.py
@@ -1,0 +1,262 @@
+# routes/auth.py
+from flask import Blueprint, request, jsonify, current_app, url_for
+from werkzeug.security import check_password_hash
+from flask_jwt_extended import (
+    create_access_token, jwt_required, get_jwt_identity
+)
+import uuid
+from datetime import datetime, timedelta
+
+from extensions import db, mail
+from models import User, Invitation, UserRole, UserStatus, Store
+from flask_mail import Message
+
+auth_bp = Blueprint('auth', __name__)
+
+@auth_bp.route('/login', methods=['POST'])
+def login():
+    """User login endpoint"""
+    data = request.get_json()
+    
+    if not data or not data.get('email') or not data.get('password'):
+        return jsonify({
+            'status': 'error',
+            'message': 'Email and password are required'
+        }), 400
+    
+    user = User.query.filter_by(email=data['email']).first()
+    
+    if not user or not user.check_password(data['password']):
+        return jsonify({
+            'status': 'error',
+            'message': 'Invalid email or password'
+        }), 401
+    
+    if user.status == UserStatus.INACTIVE:
+        return jsonify({
+            'status': 'error',
+            'message': 'Account is inactive. Please contact administrator.'
+        }), 403
+    
+    # Create access token
+    access_token = create_access_token(
+        identity={'id': user.id, 'role': user.role.value, 'store_id': user.store_id}
+    )
+    
+    return jsonify({
+        'status': 'success',
+        'message': 'Login successful',
+        'access_token': access_token,
+        'user': {
+            'id': user.id,
+            'name': user.name,
+            'email': user.email,
+            'role': user.role.name,
+            'store_id': user.store_id
+        }
+    }), 200
+
+@auth_bp.route('/register', methods=['POST'])
+def register():
+    """Register a new user with invitation token"""
+    data = request.get_json()
+    
+    if not data or not data.get('email') or not data.get('password') or not data.get('name') or not data.get('token'):
+        return jsonify({
+            'status': 'error',
+            'message': 'Name, email, password and invitation token are required'
+        }), 400
+    
+    # Verify invitation token
+    invitation = Invitation.query.filter_by(token=data['token'], email=data['email'], is_used=False).first()
+    
+    if not invitation:
+        return jsonify({
+            'status': 'error',
+            'message': 'Invalid or expired invitation token'
+        }), 400
+    
+    # Check if token is expired
+    if invitation.expires_at < datetime.utcnow():
+        return jsonify({
+            'status': 'error',
+            'message': 'Invitation token has expired'
+        }), 400
+    
+    # Check if user already exists
+    if User.query.filter_by(email=data['email']).first():
+        return jsonify({
+            'status': 'error',
+            'message': 'User with this email already exists'
+        }), 400
+    
+    # Create new user
+    new_user = User(
+        name=data['name'],
+        email=data['email'],
+        role=invitation.role,
+        status=UserStatus.ACTIVE,
+        store_id=invitation.store_id
+    )
+    new_user.password = data['password']  # Assuming User model has a password setter
+    
+    # Mark invitation as used
+    invitation.is_used = True
+    
+    db.session.add(new_user)
+    db.session.commit()
+    
+    return jsonify({
+        'status': 'success',
+        'message': 'Registration successful',
+        'user': {
+            'id': new_user.id,
+            'name': new_user.name,
+            'email': new_user.email,
+            'role': new_user.role.name,
+            'store_id': new_user.store_id
+        }
+    }), 201
+
+@auth_bp.route('/invite', methods=['POST'])
+@jwt_required()
+def invite_user():
+    """Create an invitation for a new admin or clerk"""
+    current_user_id = get_jwt_identity()['id']
+    current_user = db.session.get(User, current_user_id)  # Updated to use Session.get()
+    
+    if not current_user:
+        return jsonify({
+            'status': 'error',
+            'message': 'User not found'
+        }), 404
+    
+    data = request.get_json()
+    
+    if not data or not data.get('email') or not data.get('role'):
+        return jsonify({
+            'status': 'error',
+            'message': 'Email and role are required'
+        }), 400
+    
+    # Validate role based on inviter's role
+    requested_role = data.get('role').upper()
+    
+    # Only merchant can invite admin, admin can invite clerk
+    if (current_user.role == UserRole.MERCHANT.value and requested_role != UserRole.ADMIN.name) or \
+       (current_user.role == UserRole.ADMIN.value and requested_role != UserRole.CLERK.name):
+        return jsonify({
+            'status': 'error',
+            'message': 'You are not authorized to invite users with this role'
+        }), 403
+    
+    # Check if invitation already exists and is not used
+    existing_invitation = Invitation.query.filter_by(
+        email=data['email'], 
+        is_used=False
+    ).first()
+    
+    if existing_invitation:
+        return jsonify({
+            'status': 'error',
+            'message': 'An invitation for this email already exists'
+        }), 400
+    
+    # Generate unique token
+    token = str(uuid.uuid4())
+    
+    # Store ID handling
+    store_id = None
+    if current_user.role == UserRole.ADMIN.value:
+        store_id = current_user.store_id
+    elif data.get('store_id'):
+        # Ensure store exists
+        store = db.session.get(Store, data['store_id'])  # Updated to use Session.get()
+        if not store:
+            return jsonify({
+                'status': 'error',
+                'message': 'Store not found'
+            }), 404
+        store_id = store.id
+    
+    # Create invitation
+    invitation = Invitation(
+        email=data['email'],
+        token=token,
+        role=UserRole[requested_role],
+        creator_id=current_user_id,
+        store_id=store_id,
+        expires_at=datetime.utcnow() + current_app.config['INVITATION_EXPIRY']
+    )
+    
+    db.session.add(invitation)
+    db.session.commit()
+    
+    # Send invitation email (mocked for testing purposes)
+    registration_link = f"{request.host_url}register?token={token}&email={data['email']}"
+    
+    msg = Message(
+        "MyDuka - Account Invitation",
+        recipients=[data['email']]
+    )
+    msg.body = f"""
+    Hello,
+    
+    You have been invited to join MyDuka as a {requested_role.lower()}.
+    
+    Please click the link below to complete your registration:
+    {registration_link}
+    
+    This link will expire in {current_app.config['INVITATION_EXPIRY'].days} days.
+    
+    Regards,
+    MyDuka Team
+    """
+    
+    try:
+        mail.send(msg)
+    except Exception as e:
+        # Log the error but don't fail the request
+        current_app.logger.error(f"Error sending email: {str(e)}")
+    
+    return jsonify({
+        'status': 'success',
+        'message': 'Invitation sent successfully',
+        'registration_link': registration_link
+    }), 201
+
+@auth_bp.route('/me', methods=['GET'])
+@jwt_required()
+def get_current_user():
+    """Get current user information"""
+    current_user_id = get_jwt_identity()['id']
+    
+    user = db.session.get(User, current_user_id)  # Updated to use Session.get()
+    if not user:
+        return jsonify({
+            'status': 'error',
+            'message': 'User not found'
+        }), 404
+    
+    # Get store name if applicable
+    store_name = None
+    if user.store_id:
+        store = db.session.get(Store, user.store_id)  # Updated to use Session.get()
+        if store:
+            store_name = store.name
+    
+    return jsonify({
+        'status': 'success',
+        'user': {
+            'id': user.id,
+            'name': user.name,
+            'email': user.email,
+            'role': user.role.name,
+            'status': user.status.name,
+            'store_id': user.store_id,
+            'store_name': store_name,
+            'created_at': user.created_at.isoformat()
+        }
+    }), 200
+
+

--- a/server/tests/test_auth.py
+++ b/server/tests/test_auth.py
@@ -1,0 +1,153 @@
+# tests/test_auth.py
+import os
+import sys
+import time
+from datetime import datetime, timedelta
+import unittest
+from flask import Flask
+from flask_jwt_extended import JWTManager, create_access_token
+
+# Add the parent directory (server) to sys.path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+# Load environment variables before importing config
+from dotenv import load_dotenv
+load_dotenv()
+
+from config import config
+from extensions import db, mail
+from routes.auth import auth_bp
+from models import User, UserRole, UserStatus, Invitation, Store
+
+class AuthTestCase(unittest.TestCase):
+    def setUp(self):
+        """Set up test app and client"""
+        self.app = Flask(__name__)
+        self.app.config.from_object(config['testing'])
+        self.app.config['INVITATION_EXPIRY'] = timedelta(days=1)
+        # Set JWT_SECRET_KEY (required by JWTManager)
+        self.app.config['JWT_SECRET_KEY'] = os.environ.get('JWT_SECRET_KEY', 'your-jwt-secret-key')
+        # Initialize extensions
+        db.init_app(self.app)
+        jwt = JWTManager(self.app)
+        mail.init_app(self.app)
+        # Register blueprints
+        self.app.register_blueprint(auth_bp, url_prefix='/api/auth')
+
+        self.client = self.app.test_client()
+
+        # Use a unique identifier for emails to avoid conflicts
+        self.unique_id = str(int(time.time() * 1000))
+
+        with self.app.app_context():
+            # Drop and recreate all tables to ensure a clean state
+            db.drop_all()
+            db.create_all()
+
+            # Create a merchant user
+            merchant = User(
+                name='Test Merchant',
+                email=f'merchant_{self.unique_id}@myduka.com',
+                role=UserRole.MERCHANT,
+                status=UserStatus.ACTIVE
+            )
+            merchant.password = 'password123'
+            db.session.add(merchant)
+
+            # Create a store
+            store = Store(name='Test Store', location='123 Test St')
+            db.session.add(store)
+
+            # Create an invitation for testing
+            invitation = Invitation(
+                email=f'admin_{self.unique_id}@myduka.com',
+                token='test-token',
+                role=UserRole.ADMIN,
+                creator_id=1,
+                store_id=1,
+                expires_at=datetime.utcnow() + timedelta(days=1)
+            )
+            db.session.add(invitation)
+            db.session.commit()
+
+            # Generate token for merchant
+            self.merchant_token = create_access_token(
+                identity={'id': 1, 'role': UserRole.MERCHANT.value, 'store_id': None}
+            )
+
+    def tearDown(self):
+        """Tear down test app context"""
+        with self.app.app_context():
+            db.session.remove()
+            db.drop_all()
+
+    def test_login_merchant(self):
+        """Test merchant login"""
+        response = self.client.post('/api/auth/login', json={
+            'email': f'merchant_{self.unique_id}@myduka.com',
+            'password': 'password123'
+        })
+        self.assertEqual(response.status_code, 200)
+        data = response.get_json()
+        self.assertEqual(data['status'], 'success')
+        self.assertIn('access_token', data)
+
+    def test_login_invalid_credentials(self):
+        """Test login with invalid credentials"""
+        response = self.client.post('/api/auth/login', json={
+            'email': f'merchant_{self.unique_id}@myduka.com',
+            'password': 'wrongpassword'
+        })
+        self.assertEqual(response.status_code, 401)
+        data = response.get_json()
+        self.assertEqual(data['status'], 'error')
+        self.assertEqual(data['message'], 'Invalid email or password')
+
+    def test_register_with_invitation(self):
+        """Test registration with a valid invitation"""
+        response = self.client.post('/api/auth/register', json={
+            'token': 'test-token',
+            'email': f'admin_{self.unique_id}@myduka.com',
+            'name': 'Test Admin',
+            'password': 'admin123'
+        })
+        self.assertEqual(response.status_code, 201)
+        data = response.get_json()
+        self.assertEqual(data['status'], 'success')
+        self.assertEqual(data['message'], 'Registration successful')
+
+        with self.app.app_context():
+            user = User.query.filter_by(email=f'admin_{self.unique_id}@myduka.com').first()
+            self.assertIsNotNone(user)
+            self.assertEqual(user.name, 'Test Admin')
+            self.assertEqual(user.role, UserRole.ADMIN)
+
+    def test_invite_user_as_merchant(self):
+        """Test inviting an admin as a merchant"""
+        response = self.client.post('/api/auth/invite', json={
+            'email': f'newadmin_{self.unique_id}@myduka.com',
+            'role': 'ADMIN',
+            'store_id': 1
+        }, headers={'Authorization': f'Bearer {self.merchant_token}'})
+        self.assertEqual(response.status_code, 201)
+        data = response.get_json()
+        self.assertEqual(data['status'], 'success')
+        self.assertEqual(data['message'], 'Invitation sent successfully')
+
+        with self.app.app_context():
+            invitation = Invitation.query.filter_by(email=f'newadmin_{self.unique_id}@myduka.com').first()
+            self.assertIsNotNone(invitation)
+            self.assertFalse(invitation.is_used)
+
+    def test_get_current_user(self):
+        """Test retrieving current user information"""
+        response = self.client.get('/api/auth/me',
+                                 headers={'Authorization': f'Bearer {self.merchant_token}'})
+        self.assertEqual(response.status_code, 200)
+        data = response.get_json()
+        self.assertEqual(data['status'], 'success')
+        self.assertEqual(data['user']['email'], f'merchant_{self.unique_id}@myduka.com')
+        self.assertEqual(data['user']['role'], 'MERCHANT')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This pull request introduces and tests key authentication and user management features for the MyDuka application:
- Login (/login): Allow users to authenticate using email and password.
- Register (/register): Allow invited users to register using a valid invitation token.
- Invite User (/invite): Allow merchants to invite admins, and admins to invite clerks. Invitation emails are sent via Flask-Mail.
- Get Current User (/me): Allow logged-in users to retrieve their account details.
- Flask-Mail Integration: Added email notification for invitations with a secure token and expiry.
- Updated Test Cases: Comprehensive unit tests in tests/test_auth.py for login, registration, invitation, and current user retrieval.
- Database Updates: Use of db.session.get() to align with SQLAlchemy 2.0 style.

Other Improvements:
- Added robust error handling for expired/invalid tokens and unauthorized actions.
- Unique email identifiers in tests to avoid conflicts.
- Improved invitation expiry management with a configurable INVITATION_EXPIRY.

